### PR TITLE
Add generation of logs without drift to collection

### DIFF
--- a/concept_drifts/without_drift.py
+++ b/concept_drifts/without_drift.py
@@ -29,3 +29,14 @@ def generate_log_without_drift(tree, nu_logs):
         print("Event log 'event_log_" + str(
             i) + "_without_drift' is saved in the folder 'Data/result_data/terminal/event_logs'.")
         i = i + 1
+        
+
+def no_drift(tree, nu_traces):
+    """ Generation of an event log without any drift
+
+    :param tree: the initial version of the process model
+    :param nu_logs: number traces in event log
+    :return: event log
+    """
+    log_without_drift = semantics.generate_log(tree, nu_traces)
+    return log_without_drift


### PR DESCRIPTION
This PR adds the functionality to generate logs that do not contain any concept drift by using the generate_collection_of_logs script. For this purpose, a function called no_drift is added that returns a log based on the generated process tree without any changes. To use this behavior, the user must extend the Drifts parameter in the parameters_log_collection file with the value "none". 